### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/AuroraHub/1d16aed9-07bd-4ddb-b6d4-99cbe66924b3/fceb19a6-d6e6-4186-a5f8-9041014fcb34/_apis/work/boardbadge/20be362e-c41b-442e-8233-7bf3bb5d5703)](https://dev.azure.com/AuroraHub/1d16aed9-07bd-4ddb-b6d4-99cbe66924b3/_boards/board/t/fceb19a6-d6e6-4186-a5f8-9041014fcb34/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/AuroraHub/1d16aed9-07bd-4ddb-b6d4-99cbe66924b3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.